### PR TITLE
feat: agregar workspace ai-sentinel con stack AI + Fleet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 .vault_pass
 **/sops*.yml
 *.sops
+**/*.crt
+**/*.key
 
 # Python
 __pycache__/

--- a/src/ai-sentinel/Como usarlo.md
+++ b/src/ai-sentinel/Como usarlo.md
@@ -1,0 +1,64 @@
+# Guía rápida de uso (AI Stack + Fleet)
+
+Antes de levantar el stack con `docker compose`, hay 3 cosas importantes que debes tener en cuenta:
+
+---
+
+## 1) Certificados TLS (carpeta `certs/`)
+
+Debes generar los certificados TLS dentro de la carpeta `certs/` **antes** de levantar el compose.
+
+📌 Sigue las instrucciones del archivo `.md` que está dentro de `certs/`.
+
+---
+
+## 2) Dominio / IP usada en los certificados (MUY IMPORTANTE)
+
+Cuando generes los certificados TLS, vas a definir un `CN` con un **dominio o IP**.
+
+Ese valor será importante porque:
+
+- Será la dirección desde donde podrás acceder a Fleet (UI/API).
+- Será la dirección a la que los instaladores generados por Fleet intentarán conectarse (enroll).
+- Será la dirección que los endpoints con `osquery` usarán para conectarse al servidor.
+
+---
+
+### Caso A: Usar `localhost`
+Si generas certificados con `localhost`:
+
+✅ Podrás acceder a Fleet desde el mismo servidor fácilmente.  
+❌ Pero los endpoints (otras máquinas) **nunca podrán conectarse** a Fleet, porque para ellos `localhost` significa “ellos mismos”.
+
+---
+
+### Caso B: Usar un dominio o IP real
+Si generas certificados con un dominio custom (ej: `fleet.midominio.com`) o con la IP pública del servidor:
+
+✅ El servidor podrá exponer Fleet correctamente.  
+✅ Los endpoints podrán conectarse y enrollarse sin problema.
+
+📌 Importante:
+- El servidor donde levantes el compose debe resolver ese dominio hacia su propia IP.
+- Los endpoints también deben resolver ese dominio hacia la IP actual del servidor.
+
+Esto se puede lograr con:
+- DNS público (Cloudflare, etc.)
+- o entradas en el archivo `hosts` (solo para pruebas).
+
+---
+
+## 3) Producción: cambiar la llave privada de Fleet
+
+En el archivo `.env` existe una variable llamada:
+
+`FLEET_SERVER_PRIVATE_KEY`
+
+Por defecto puede venir con un valor "demo" para que el stack levante sin problemas.
+
+⚠️ **Si vas a usar esto en producción, debes cambiar esta llave.**
+
+Puedes generar una llave segura con:
+
+```bash
+openssl rand -base64 32

--- a/src/ai-sentinel/ai_stack.dockerignore
+++ b/src/ai-sentinel/ai_stack.dockerignore
@@ -1,0 +1,18 @@
+# Ignorar todo
+**
+
+# ← EXCEPCIONES (cosas que SÍ quieres incluir)
+!Dockerfile
+!docker-compose.yml
+
+# Importante: incluir la carpeta ollama y su contenido
+!ollama/
+!ollama/**
+
+# Importante: incluir la carpeta postgres y su contenido
+!postgres/
+!postgres/**
+
+# Importante: incluir la carpeta certs y su contenido (si lo hay)
+!certs/
+!certs/**

--- a/src/ai-sentinel/certs/que va aqui.md
+++ b/src/ai-sentinel/certs/que va aqui.md
@@ -1,0 +1,43 @@
+# Certificados TLS para Fleet
+
+En esta carpeta se generan los certificados TLS necesarios para **Fleet**.
+
+⚠️ **Importante:** estos certificados deben crearse **antes** de levantar el `docker-compose.yml`, ya que Fleet monta los archivos desde `./certs/`.
+
+---
+
+## Requisitos
+- Servidor Linux con `openssl` instalado.
+
+---
+
+## Generar certificados (self-signed)
+
+Ejecuta estos comandos desde la raíz del proyecto:
+
+```bash
+mkdir -p certs
+
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout certs/fleet.key \
+  -out certs/fleet.crt \
+  -subj "/CN=<FQDN_OR_IP>"
+
+```
+⚠️ **Importante:**
+
+Reemplaza <FQDN_OR_IP> por el dominio o IP del servidor donde se levantará Fleet, posteriorment osquery apuntara alli.
+
+Ejemplo:
+
+```bash
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+  -keyout certs/fleet.key \
+  -out certs/fleet.crt \
+  -subj "/CN=mi-servidor.com"
+```
+
+## Darle permisos (recomendado)
+```bash
+chmod 644 certs/fleet.key certs/fleet.crt
+```

--- a/src/ai-sentinel/dev.env.example
+++ b/src/ai-sentinel/dev.env.example
@@ -1,0 +1,97 @@
+##################################  AI_Stack Configuration   #################
+
+# -----------------------------
+# OLLAMA
+# -----------------------------
+OLLAMA_PORT=11434
+
+# Modelos a descargar al iniciar el container (separados por espacios).
+# NOTA: por ahora solo usar 1 modelo de embeddings.
+OLLAMA_MODELS="nomic-embed-text:latest ministral-3:3B"
+
+# Tamaño del embedding (dimensión del vector).
+# Debe coincidir con el modelo de embedding que usaran (nomic-embed-text:latest)
+# Este sera usado para crear una tabla en postgres que almacene vectores de dicho tamaño
+EMBEDDING_SIZE=768
+
+# -----------------------------
+# POSTGRES
+# -----------------------------
+POSTGRES_USER=admin
+POSTGRES_PASSWORD=admin
+POSTGRES_DB=flowise
+POSTGRES_PORT=5432
+
+# -----------------------------
+# FLOWISE
+# -----------------------------
+FLOWISE_PORT=3000
+DATABASE_SCHEMA=public
+
+OLLAMA_BASE_URL=http://ollama:11434
+
+
+# ========================
+# n8n
+# ========================
+N8N_PORT=5678
+N8N_TIMEZONE=America/Panama
+
+
+
+
+
+##################################  Fleet Compose Configuration  #################
+# -----------------------------
+# MYSQL
+# -----------------------------
+MYSQL_ROOT_PASSWORD=admin123
+MYSQL_DATABASE=fleet
+MYSQL_USER=fleet
+MYSQL_PASSWORD=fleet123
+
+# -----------------------------
+# Fleet Server
+# -----------------------------
+# Generate a random key with: openssl rand -base64 32
+#TODO: CAMBIA ESTA LLAVE EN PRODUCCION... ESTA ESDE PRUEBAS, SOLO PARA DESARROLLO
+FLEET_SERVER_PRIVATE_KEY=5xJNDT0n0w7J3jUuQUdeXyRJ7x3Z/TyVtuL+qlsTM8I=
+
+# Fleet HTTP Listener Configuration
+FLEET_SERVER_ADDRESS=0.0.0.0
+FLEET_SERVER_PORT=1337
+
+# TLS Configuration
+# Set to 'true' if Fleet handles TLS directly (requires certificates in ./certs/)
+# Set to 'false' if using a reverse proxy or load balancer for TLS termination
+FLEET_SERVER_TLS=true
+
+# TLS Certificate paths (only needed if FLEET_SERVER_TLS=true)
+FLEET_SERVER_CERT=/fleet/fleet.crt
+FLEET_SERVER_KEY=/fleet/fleet.key
+
+# Fleet License (optional - leave empty for free tier)
+FLEET_LICENSE_KEY=
+
+# Fleet Session & Logging
+FLEET_SESSION_DURATION=24h
+FLEET_LOGGING_JSON=true
+
+# Fleet Osquery Configuration
+FLEET_OSQUERY_STATUS_LOG_PLUGIN=filesystem
+FLEET_FILESYSTEM_STATUS_LOG_FILE=/logs/osqueryd.status.log
+FLEET_FILESYSTEM_RESULT_LOG_FILE=/logs/osqueryd.results.log
+FLEET_OSQUERY_LABEL_UPDATE_INTERVAL=1h
+
+# Fleet Vulnerabilities
+FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS=yes
+FLEET_VULNERABILITIES_DATABASES_PATH=/vulndb
+FLEET_VULNERABILITIES_PERIODICITY=1h
+
+# S3 Configuration (optional - leave empty if not using S3)
+FLEET_S3_SOFTWARE_INSTALLERS_BUCKET=
+FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID=
+FLEET_S3_SOFTWARE_INSTALLERS_SECRET_ACCESS_KEY=
+FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE=
+FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL=
+FLEET_S3_SOFTWARE_INSTALLERS_REGION=

--- a/src/ai-sentinel/docker-compose.dev.yml
+++ b/src/ai-sentinel/docker-compose.dev.yml
@@ -1,0 +1,206 @@
+volumes:
+# -----------------------------
+# AI_Stack volumes
+# Volumenes agregados en el desarrollo
+# -----------------------------
+  ollama_data:
+  postgres_data:
+  flowise_data:
+  n8n_data:
+# -----------------------------
+# Fleet Compose volumes
+# Los siguientes volumenes son proporcionados por el compose oficial de fleets
+# -----------------------------
+  mysql:
+  redis:
+  data:
+  logs:
+  vulndb:
+
+services:
+##################################  AI_Stack  ###############################################################
+# Compose desarrollado
+  ollama:
+    build:
+      context: ./ollama
+    container_name: ollama
+    environment:
+          OLLAMA_MODELS: ${OLLAMA_MODELS}
+    ports:
+      - "${OLLAMA_PORT}:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
+
+  postgres:
+    build: ./postgres
+    container_name: postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      EMBEDDING_SIZE: ${EMBEDDING_SIZE}
+    ports:
+      - "${POSTGRES_PORT}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  flowise:
+    image: flowiseai/flowise:latest
+    container_name: flowise
+    depends_on:
+      postgres:
+        condition: service_healthy
+      ollama:
+        condition: service_started
+    environment:
+      PORT: ${FLOWISE_PORT}
+      DATABASE_SCHEMA: ${DATABASE_SCHEMA}
+      DATABASE_TYPE: postgres
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      DATABASE_NAME: ${POSTGRES_DB}
+      DATABASE_USER: ${POSTGRES_USER}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
+
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL}
+    ports:
+      - "${FLOWISE_PORT}:${FLOWISE_PORT}"
+    volumes:
+      - flowise_data:/root/.flowise
+    restart: unless-stopped
+
+  n8n:
+      image: docker.n8n.io/n8nio/n8n
+      container_name: n8n
+      ports:
+        - "${N8N_PORT}:5678"
+      environment:
+        GENERIC_TIMEZONE: ${N8N_TIMEZONE}
+        TZ: ${N8N_TIMEZONE}
+        N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS: "true"
+        N8N_RUNNERS_ENABLED: "true"
+      volumes:
+        - n8n_data:/home/node/.n8n
+      restart: unless-stopped
+
+
+##################################  Fleet Compose Configuration  ###################################################
+# El siguiente fragmento de compose es un copy/paste del proporcionado oficialmente por fleets
+  mysql:
+    image: mysql:8
+    platform: linux/x86_64
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+    volumes:
+      - mysql:/var/lib/mysql
+    cap_add:
+      - SYS_NICE
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD --silent || exit 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    ports:
+      - "3306:3306"
+    restart: unless-stopped
+
+  redis:
+    image: redis:6
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
+  fleet-init:
+    image: alpine:latest
+    volumes:
+      - logs:/logs
+      - data:/data
+      - vulndb:/vulndb
+    command: sh -c "chown -R 100:101 /logs /data /vulndb"
+
+  fleet:
+    image: fleetdm/fleet
+    platform: linux/x86_64
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      fleet-init:
+        condition: service_completed_successfully
+    command: sh -c "/usr/bin/fleet prepare db --no-prompt && /usr/bin/fleet serve"
+    environment:
+      # In-cluster service addresses (no hostnames/ports on the host)
+      - FLEET_REDIS_ADDRESS=redis:6379
+      - FLEET_MYSQL_ADDRESS=mysql:3306
+      - FLEET_MYSQL_DATABASE=${MYSQL_DATABASE}
+      - FLEET_MYSQL_USERNAME=${MYSQL_USER}
+      - FLEET_MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      # Fleet HTTP listener
+      - FLEET_SERVER_ADDRESS=${FLEET_SERVER_ADDRESS}:${FLEET_SERVER_PORT}
+      - FLEET_SERVER_TLS=${FLEET_SERVER_TLS}
+      # TLS Certificate paths (only needed if FLEET_SERVER_TLS=true)
+      - FLEET_SERVER_CERT=${FLEET_SERVER_CERT}
+      - FLEET_SERVER_KEY=${FLEET_SERVER_KEY}
+      # Secrets
+      - FLEET_SERVER_PRIVATE_KEY=${FLEET_SERVER_PRIVATE_KEY} # Run 'openssl rand -base64 32' to generate
+      - FLEET_LICENSE_KEY=${FLEET_LICENSE_KEY}
+      # System tuning & other options
+      - FLEET_SESSION_DURATION=${FLEET_SESSION_DURATION}
+      - FLEET_LOGGING_JSON=${FLEET_LOGGING_JSON}
+      - FLEET_OSQUERY_STATUS_LOG_PLUGIN=${FLEET_OSQUERY_STATUS_LOG_PLUGIN}
+      - FLEET_FILESYSTEM_STATUS_LOG_FILE=${FLEET_FILESYSTEM_STATUS_LOG_FILE}
+      - FLEET_FILESYSTEM_RESULT_LOG_FILE=${FLEET_FILESYSTEM_RESULT_LOG_FILE}
+      - FLEET_OSQUERY_LABEL_UPDATE_INTERVAL=${FLEET_OSQUERY_LABEL_UPDATE_INTERVAL}
+      - FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS=${FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS}
+      - FLEET_VULNERABILITIES_DATABASES_PATH=${FLEET_VULNERABILITIES_DATABASES_PATH}
+      - FLEET_VULNERABILITIES_PERIODICITY=${FLEET_VULNERABILITIES_PERIODICITY}
+      # Optional S3 info
+      # - FLEET_S3_SOFTWARE_INSTALLERS_BUCKET=${FLEET_S3_SOFTWARE_INSTALLERS_BUCKET}
+      # - FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID=${FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID}
+      # - FLEET_S3_SOFTWARE_INSTALLERS_SECRET_ACCESS_KEY=${FLEET_S3_SOFTWARE_INSTALLERS_SECRET_ACCESS_KEY}
+      # - FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE=${FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE}
+      # Override FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL when using a different S3 compatible
+      # object storage backend (such as RustFS) or running S3 locally with localstack.
+      # Leave this blank to use the default S3 service endpoint.
+      # - FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL=${FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL}
+      # RustFS users should set FLEET_S3_SOFTWARE_INSTALLERS_REGION to any nonempty value (eg. localhost)
+      # to short-circuit region discovery
+      # - FLEET_S3_SOFTWARE_INSTALLERS_REGION=${FLEET_S3_SOFTWARE_INSTALLERS_REGION}
+    ports:
+      - "${FLEET_SERVER_PORT}:${FLEET_SERVER_PORT}" # UI/API
+    volumes:
+      - data:/fleet
+      - logs:/logs
+      - vulndb:${FLEET_VULNERABILITIES_DATABASES_PATH}
+      - ./certs/fleet.crt:/fleet/fleet.crt:ro
+      - ./certs/fleet.key:/fleet/fleet.key:ro
+    healthcheck:
+      test:
+        ["CMD", "wget", "-qO-", "http://127.0.0.1:${FLEET_SERVER_PORT}/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    restart: unless-stopped

--- a/src/ai-sentinel/docker-compose.prod.yml
+++ b/src/ai-sentinel/docker-compose.prod.yml
@@ -1,0 +1,205 @@
+volumes:
+# -----------------------------
+# AI_Stack volumes
+# Volumenes agregados en el desarrollo
+# -----------------------------
+  ollama_data:
+  postgres_data:
+  flowise_data:
+  n8n_data:
+# -----------------------------
+# Fleet Compose volumes
+# Los siguientes volumenes son proporcionados por el compose oficial de fleets
+# -----------------------------
+  mysql:
+  redis:
+  data:
+  logs:
+  vulndb:
+
+services:
+##################################  AI_Stack  ###############################################################
+# Compose desarrollado
+  ollama:
+    image: jjsotom2k4/ollama-ai:${VERSION}
+    container_name: ollama
+    environment:
+          OLLAMA_MODELS: ${OLLAMA_MODELS}
+    ports:
+      - "${OLLAMA_PORT}:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
+
+  postgres:
+    image: jjsotom2k4/postgres-ai:${VERSION}
+    container_name: postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      EMBEDDING_SIZE: ${EMBEDDING_SIZE}
+    ports:
+      - "${POSTGRES_PORT}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  flowise:
+    image: flowiseai/flowise:latest
+    container_name: flowise
+    depends_on:
+      postgres:
+        condition: service_healthy
+      ollama:
+        condition: service_started
+    environment:
+      PORT: ${FLOWISE_PORT}
+      DATABASE_SCHEMA: ${DATABASE_SCHEMA}
+      DATABASE_TYPE: postgres
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      DATABASE_NAME: ${POSTGRES_DB}
+      DATABASE_USER: ${POSTGRES_USER}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
+
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL}
+    ports:
+      - "${FLOWISE_PORT}:${FLOWISE_PORT}"
+    volumes:
+      - flowise_data:/root/.flowise
+    restart: unless-stopped
+
+  n8n:
+      image: docker.n8n.io/n8nio/n8n
+      container_name: n8n
+      ports:
+        - "${N8N_PORT}:5678"
+      environment:
+        GENERIC_TIMEZONE: ${N8N_TIMEZONE}
+        TZ: ${N8N_TIMEZONE}
+        N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS: "true"
+        N8N_RUNNERS_ENABLED: "true"
+      volumes:
+        - n8n_data:/home/node/.n8n
+      restart: unless-stopped
+
+
+##################################  Fleet Compose Configuration  ###################################################
+# El siguiente fragmento de compose es un copy/paste del proporcionado oficialmente por fleets
+  mysql:
+    image: mysql:8
+    platform: linux/x86_64
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+    volumes:
+      - mysql:/var/lib/mysql
+    cap_add:
+      - SYS_NICE
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD --silent || exit 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    ports:
+      - "3306:3306"
+    restart: unless-stopped
+
+  redis:
+    image: redis:6
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
+  fleet-init:
+    image: alpine:latest
+    volumes:
+      - logs:/logs
+      - data:/data
+      - vulndb:/vulndb
+    command: sh -c "chown -R 100:101 /logs /data /vulndb"
+
+  fleet:
+    image: fleetdm/fleet
+    platform: linux/x86_64
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      fleet-init:
+        condition: service_completed_successfully
+    command: sh -c "/usr/bin/fleet prepare db --no-prompt && /usr/bin/fleet serve"
+    environment:
+      # In-cluster service addresses (no hostnames/ports on the host)
+      - FLEET_REDIS_ADDRESS=redis:6379
+      - FLEET_MYSQL_ADDRESS=mysql:3306
+      - FLEET_MYSQL_DATABASE=${MYSQL_DATABASE}
+      - FLEET_MYSQL_USERNAME=${MYSQL_USER}
+      - FLEET_MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      # Fleet HTTP listener
+      - FLEET_SERVER_ADDRESS=${FLEET_SERVER_ADDRESS}:${FLEET_SERVER_PORT}
+      - FLEET_SERVER_TLS=${FLEET_SERVER_TLS}
+      # TLS Certificate paths (only needed if FLEET_SERVER_TLS=true)
+      - FLEET_SERVER_CERT=${FLEET_SERVER_CERT}
+      - FLEET_SERVER_KEY=${FLEET_SERVER_KEY}
+      # Secrets
+      - FLEET_SERVER_PRIVATE_KEY=${FLEET_SERVER_PRIVATE_KEY} # Run 'openssl rand -base64 32' to generate
+      - FLEET_LICENSE_KEY=${FLEET_LICENSE_KEY}
+      # System tuning & other options
+      - FLEET_SESSION_DURATION=${FLEET_SESSION_DURATION}
+      - FLEET_LOGGING_JSON=${FLEET_LOGGING_JSON}
+      - FLEET_OSQUERY_STATUS_LOG_PLUGIN=${FLEET_OSQUERY_STATUS_LOG_PLUGIN}
+      - FLEET_FILESYSTEM_STATUS_LOG_FILE=${FLEET_FILESYSTEM_STATUS_LOG_FILE}
+      - FLEET_FILESYSTEM_RESULT_LOG_FILE=${FLEET_FILESYSTEM_RESULT_LOG_FILE}
+      - FLEET_OSQUERY_LABEL_UPDATE_INTERVAL=${FLEET_OSQUERY_LABEL_UPDATE_INTERVAL}
+      - FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS=${FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS}
+      - FLEET_VULNERABILITIES_DATABASES_PATH=${FLEET_VULNERABILITIES_DATABASES_PATH}
+      - FLEET_VULNERABILITIES_PERIODICITY=${FLEET_VULNERABILITIES_PERIODICITY}
+      # Optional S3 info
+      # - FLEET_S3_SOFTWARE_INSTALLERS_BUCKET=${FLEET_S3_SOFTWARE_INSTALLERS_BUCKET}
+      # - FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID=${FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID}
+      # - FLEET_S3_SOFTWARE_INSTALLERS_SECRET_ACCESS_KEY=${FLEET_S3_SOFTWARE_INSTALLERS_SECRET_ACCESS_KEY}
+      # - FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE=${FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE}
+      # Override FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL when using a different S3 compatible
+      # object storage backend (such as RustFS) or running S3 locally with localstack.
+      # Leave this blank to use the default S3 service endpoint.
+      # - FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL=${FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL}
+      # RustFS users should set FLEET_S3_SOFTWARE_INSTALLERS_REGION to any nonempty value (eg. localhost)
+      # to short-circuit region discovery
+      # - FLEET_S3_SOFTWARE_INSTALLERS_REGION=${FLEET_S3_SOFTWARE_INSTALLERS_REGION}
+    ports:
+      - "${FLEET_SERVER_PORT}:${FLEET_SERVER_PORT}" # UI/API
+    volumes:
+      - data:/fleet
+      - logs:/logs
+      - vulndb:${FLEET_VULNERABILITIES_DATABASES_PATH}
+      - ./certs/fleet.crt:/fleet/fleet.crt:ro
+      - ./certs/fleet.key:/fleet/fleet.key:ro
+    healthcheck:
+      test:
+        ["CMD", "wget", "-qO-", "http://127.0.0.1:${FLEET_SERVER_PORT}/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    restart: unless-stopped

--- a/src/ai-sentinel/docker-compose.test.yml
+++ b/src/ai-sentinel/docker-compose.test.yml
@@ -1,0 +1,205 @@
+volumes:
+# -----------------------------
+# AI_Stack volumes
+# Volumenes agregados en el desarrollo
+# -----------------------------
+  ollama_data:
+  postgres_data:
+  flowise_data:
+  n8n_data:
+# -----------------------------
+# Fleet Compose volumes
+# Los siguientes volumenes son proporcionados por el compose oficial de fleets
+# -----------------------------
+  mysql:
+  redis:
+  data:
+  logs:
+  vulndb:
+
+services:
+##################################  AI_Stack  ###############################################################
+# Compose desarrollado
+  ollama:
+    image: jjsotom2k4/ollama-ai:${VERSION}
+    container_name: ollama
+    environment:
+          OLLAMA_MODELS: ${OLLAMA_MODELS}
+    ports:
+      - "${OLLAMA_PORT}:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
+
+  postgres:
+    image: jjsotom2k4/postgres-ai:${VERSION}
+    container_name: postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+      EMBEDDING_SIZE: ${EMBEDDING_SIZE}
+    ports:
+      - "${POSTGRES_PORT}:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  flowise:
+    image: flowiseai/flowise:latest
+    container_name: flowise
+    depends_on:
+      postgres:
+        condition: service_healthy
+      ollama:
+        condition: service_started
+    environment:
+      PORT: ${FLOWISE_PORT}
+      DATABASE_SCHEMA: ${DATABASE_SCHEMA}
+      DATABASE_TYPE: postgres
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      DATABASE_NAME: ${POSTGRES_DB}
+      DATABASE_USER: ${POSTGRES_USER}
+      DATABASE_PASSWORD: ${POSTGRES_PASSWORD}
+
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL}
+    ports:
+      - "${FLOWISE_PORT}:${FLOWISE_PORT}"
+    volumes:
+      - flowise_data:/root/.flowise
+    restart: unless-stopped
+
+  n8n:
+      image: docker.n8n.io/n8nio/n8n
+      container_name: n8n
+      ports:
+        - "${N8N_PORT}:5678"
+      environment:
+        GENERIC_TIMEZONE: ${N8N_TIMEZONE}
+        TZ: ${N8N_TIMEZONE}
+        N8N_ENFORCE_SETTINGS_FILE_PERMISSIONS: "true"
+        N8N_RUNNERS_ENABLED: "true"
+      volumes:
+        - n8n_data:/home/node/.n8n
+      restart: unless-stopped
+
+
+##################################  Fleet Compose Configuration  ###################################################
+# El siguiente fragmento de compose es un copy/paste del proporcionado oficialmente por fleets
+  mysql:
+    image: mysql:8
+    platform: linux/x86_64
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+    volumes:
+      - mysql:/var/lib/mysql
+    cap_add:
+      - SYS_NICE
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "mysqladmin ping -h 127.0.0.1 -u$$MYSQL_USER -p$$MYSQL_PASSWORD --silent || exit 1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    ports:
+      - "3306:3306"
+    restart: unless-stopped
+
+  redis:
+    image: redis:6
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+
+  fleet-init:
+    image: alpine:latest
+    volumes:
+      - logs:/logs
+      - data:/data
+      - vulndb:/vulndb
+    command: sh -c "chown -R 100:101 /logs /data /vulndb"
+
+  fleet:
+    image: fleetdm/fleet
+    platform: linux/x86_64
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      fleet-init:
+        condition: service_completed_successfully
+    command: sh -c "/usr/bin/fleet prepare db --no-prompt && /usr/bin/fleet serve"
+    environment:
+      # In-cluster service addresses (no hostnames/ports on the host)
+      - FLEET_REDIS_ADDRESS=redis:6379
+      - FLEET_MYSQL_ADDRESS=mysql:3306
+      - FLEET_MYSQL_DATABASE=${MYSQL_DATABASE}
+      - FLEET_MYSQL_USERNAME=${MYSQL_USER}
+      - FLEET_MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      # Fleet HTTP listener
+      - FLEET_SERVER_ADDRESS=${FLEET_SERVER_ADDRESS}:${FLEET_SERVER_PORT}
+      - FLEET_SERVER_TLS=${FLEET_SERVER_TLS}
+      # TLS Certificate paths (only needed if FLEET_SERVER_TLS=true)
+      - FLEET_SERVER_CERT=${FLEET_SERVER_CERT}
+      - FLEET_SERVER_KEY=${FLEET_SERVER_KEY}
+      # Secrets
+      - FLEET_SERVER_PRIVATE_KEY=${FLEET_SERVER_PRIVATE_KEY} # Run 'openssl rand -base64 32' to generate
+      - FLEET_LICENSE_KEY=${FLEET_LICENSE_KEY}
+      # System tuning & other options
+      - FLEET_SESSION_DURATION=${FLEET_SESSION_DURATION}
+      - FLEET_LOGGING_JSON=${FLEET_LOGGING_JSON}
+      - FLEET_OSQUERY_STATUS_LOG_PLUGIN=${FLEET_OSQUERY_STATUS_LOG_PLUGIN}
+      - FLEET_FILESYSTEM_STATUS_LOG_FILE=${FLEET_FILESYSTEM_STATUS_LOG_FILE}
+      - FLEET_FILESYSTEM_RESULT_LOG_FILE=${FLEET_FILESYSTEM_RESULT_LOG_FILE}
+      - FLEET_OSQUERY_LABEL_UPDATE_INTERVAL=${FLEET_OSQUERY_LABEL_UPDATE_INTERVAL}
+      - FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS=${FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS}
+      - FLEET_VULNERABILITIES_DATABASES_PATH=${FLEET_VULNERABILITIES_DATABASES_PATH}
+      - FLEET_VULNERABILITIES_PERIODICITY=${FLEET_VULNERABILITIES_PERIODICITY}
+      # Optional S3 info
+      # - FLEET_S3_SOFTWARE_INSTALLERS_BUCKET=${FLEET_S3_SOFTWARE_INSTALLERS_BUCKET}
+      # - FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID=${FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID}
+      # - FLEET_S3_SOFTWARE_INSTALLERS_SECRET_ACCESS_KEY=${FLEET_S3_SOFTWARE_INSTALLERS_SECRET_ACCESS_KEY}
+      # - FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE=${FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE}
+      # Override FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL when using a different S3 compatible
+      # object storage backend (such as RustFS) or running S3 locally with localstack.
+      # Leave this blank to use the default S3 service endpoint.
+      # - FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL=${FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL}
+      # RustFS users should set FLEET_S3_SOFTWARE_INSTALLERS_REGION to any nonempty value (eg. localhost)
+      # to short-circuit region discovery
+      # - FLEET_S3_SOFTWARE_INSTALLERS_REGION=${FLEET_S3_SOFTWARE_INSTALLERS_REGION}
+    ports:
+      - "${FLEET_SERVER_PORT}:${FLEET_SERVER_PORT}" # UI/API
+    volumes:
+      - data:/fleet
+      - logs:/logs
+      - vulndb:${FLEET_VULNERABILITIES_DATABASES_PATH}
+      - ./certs/fleet.crt:/fleet/fleet.crt:ro
+      - ./certs/fleet.key:/fleet/fleet.key:ro
+    healthcheck:
+      test:
+        ["CMD", "wget", "-qO-", "http://127.0.0.1:${FLEET_SERVER_PORT}/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+    restart: unless-stopped

--- a/src/ai-sentinel/ollama/Dockerfile
+++ b/src/ai-sentinel/ollama/Dockerfile
@@ -1,0 +1,10 @@
+FROM ollama/ollama:latest
+
+EXPOSE 11434
+
+COPY start.sh /start.sh
+
+# Quita CRLF si viene de Windows y asegura permisos
+RUN sed -i 's/\r$//' /start.sh && chmod +x /start.sh
+
+ENTRYPOINT ["/bin/sh", "/start.sh"]

--- a/src/ai-sentinel/ollama/start.sh
+++ b/src/ai-sentinel/ollama/start.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+if [ -z "$OLLAMA_MODELS" ]; then
+  echo " ERROR: La variable OLLAMA_MODELS no está definida."
+  echo " Debes definirla en el archivo .env o en docker-compose.yml"
+  exit 1
+fi
+
+echo "Iniciando Ollama..."
+ollama serve &
+
+sleep 5
+
+echo "Modelos a descargar: $OLLAMA_MODELS"
+
+for model in $OLLAMA_MODELS; do
+  echo "Descargando $model ..."
+  ollama pull "$model"
+done
+
+wait

--- a/src/ai-sentinel/postgres/Dockerfile
+++ b/src/ai-sentinel/postgres/Dockerfile
@@ -1,0 +1,6 @@
+FROM ankane/pgvector:latest
+
+#Copiar script de inicio configurado a la carpeta de ejecucion post build
+COPY init-db.sh /docker-entrypoint-initdb.d/init-db.sh
+#darle permisos de ejecucion
+RUN chmod +x /docker-entrypoint-initdb.d/init-db.sh

--- a/src/ai-sentinel/postgres/create_database.txt
+++ b/src/ai-sentinel/postgres/create_database.txt
@@ -1,0 +1,15 @@
+
+-- Tabla que Flowise está intentando usar
+CREATE TABLE IF NOT EXISTS public.documents (
+  id uuid PRIMARY KEY,
+  "pageContent" text,
+  metadata jsonb,
+  embedding vector(768)
+);
+
+-- Índice para búsquedas por similitud con COSINE (lo que elegiste)
+CREATE INDEX IF NOT EXISTS documents_embedding_idx
+ON public.documents USING ivfflat (embedding vector_cosine_ops)
+WITH (lists = 100);
+
+ANALYZE public.documents;

--- a/src/ai-sentinel/postgres/init-db.sh
+++ b/src/ai-sentinel/postgres/init-db.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+echo "==> Ejecutando script manual con EMBEDDING_SIZE=${EMBEDDING_SIZE}"
+
+psql -v ON_ERROR_STOP=1 \
+    -U "$POSTGRES_USER" \
+    -d "$POSTGRES_DB" <<SQL
+
+-- Crear extensión vector
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Crear tabla documents
+CREATE TABLE IF NOT EXISTS public.documents (
+  id uuid PRIMARY KEY,
+  "pageContent" text,
+  metadata jsonb,
+  embedding vector(${EMBEDDING_SIZE})
+);
+
+-- Crear índice vectorial
+CREATE INDEX IF NOT EXISTS documents_embedding_idx
+ON public.documents
+USING ivfflat (embedding vector_cosine_ops)
+WITH (lists = 100);
+
+ANALYZE public.documents;
+
+SQL
+
+echo "==> Script finalizado correctamente."
+echo ">>> INIT POSTGRES TERMINADO <<<"

--- a/src/ai-sentinel/prod.env.example
+++ b/src/ai-sentinel/prod.env.example
@@ -1,0 +1,98 @@
+##################################  AI_Stack Configuration   #################
+VERSION=1.0.0
+
+# -----------------------------
+# OLLAMA
+# -----------------------------
+OLLAMA_PORT=11434
+
+# Modelos a descargar al iniciar el container (separados por espacios).
+# NOTA: por ahora solo usar 1 modelo de embeddings.
+OLLAMA_MODELS="nomic-embed-text:latest ministral-3:3B"
+
+# Tamaño del embedding (dimensión del vector).
+# Debe coincidir con el modelo de embedding que usaran (nomic-embed-text:latest)
+# Este sera usado para crear una tabla en postgres que almacene vectores de dicho tamaño
+EMBEDDING_SIZE=768
+
+# -----------------------------
+# POSTGRES
+# -----------------------------
+POSTGRES_USER=admin
+POSTGRES_PASSWORD=admin
+POSTGRES_DB=flowise
+POSTGRES_PORT=5432
+
+# -----------------------------
+# FLOWISE
+# -----------------------------
+FLOWISE_PORT=3000
+DATABASE_SCHEMA=public
+
+OLLAMA_BASE_URL=http://ollama:11434
+
+
+# ========================
+# n8n
+# ========================
+N8N_PORT=5678
+N8N_TIMEZONE=America/Panama
+
+
+
+
+
+##################################  Fleet Compose Configuration  #################
+# -----------------------------
+# MYSQL
+# -----------------------------
+MYSQL_ROOT_PASSWORD=admin123
+MYSQL_DATABASE=fleet
+MYSQL_USER=fleet
+MYSQL_PASSWORD=fleet123
+
+# -----------------------------
+# Fleet Server
+# -----------------------------
+# Generate a random key with: openssl rand -base64 32
+#TODO: CAMBIA ESTA LLAVE EN PRODUCCION... ESTA ESDE PRUEBAS, SOLO PARA DESARROLLO
+FLEET_SERVER_PRIVATE_KEY=5xJNDT0n0w7J3jUuQUdeXyRJ7x3Z/TyVtuL+qlsTM8I=
+
+# Fleet HTTP Listener Configuration
+FLEET_SERVER_ADDRESS=0.0.0.0
+FLEET_SERVER_PORT=1337
+
+# TLS Configuration
+# Set to 'true' if Fleet handles TLS directly (requires certificates in ./certs/)
+# Set to 'false' if using a reverse proxy or load balancer for TLS termination
+FLEET_SERVER_TLS=true
+
+# TLS Certificate paths (only needed if FLEET_SERVER_TLS=true)
+FLEET_SERVER_CERT=/fleet/fleet.crt
+FLEET_SERVER_KEY=/fleet/fleet.key
+
+# Fleet License (optional - leave empty for free tier)
+FLEET_LICENSE_KEY=
+
+# Fleet Session & Logging
+FLEET_SESSION_DURATION=24h
+FLEET_LOGGING_JSON=true
+
+# Fleet Osquery Configuration
+FLEET_OSQUERY_STATUS_LOG_PLUGIN=filesystem
+FLEET_FILESYSTEM_STATUS_LOG_FILE=/logs/osqueryd.status.log
+FLEET_FILESYSTEM_RESULT_LOG_FILE=/logs/osqueryd.results.log
+FLEET_OSQUERY_LABEL_UPDATE_INTERVAL=1h
+
+# Fleet Vulnerabilities
+FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS=yes
+FLEET_VULNERABILITIES_DATABASES_PATH=/vulndb
+FLEET_VULNERABILITIES_PERIODICITY=1h
+
+# S3 Configuration (optional - leave empty if not using S3)
+FLEET_S3_SOFTWARE_INSTALLERS_BUCKET=
+FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID=
+FLEET_S3_SOFTWARE_INSTALLERS_SECRET_ACCESS_KEY=
+FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE=
+FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL=
+FLEET_S3_SOFTWARE_INSTALLERS_REGION=

--- a/src/ai-sentinel/test.env.example
+++ b/src/ai-sentinel/test.env.example
@@ -1,0 +1,98 @@
+##################################  AI_Stack Configuration   #################
+VERSION=1.0.0
+
+# -----------------------------
+# OLLAMA
+# -----------------------------
+OLLAMA_PORT=11434
+
+# Modelos a descargar al iniciar el container (separados por espacios).
+# NOTA: por ahora solo usar 1 modelo de embeddings.
+OLLAMA_MODELS="nomic-embed-text:latest ministral-3:3B"
+
+# Tamaño del embedding (dimensión del vector).
+# Debe coincidir con el modelo de embedding que usaran (nomic-embed-text:latest)
+# Este sera usado para crear una tabla en postgres que almacene vectores de dicho tamaño
+EMBEDDING_SIZE=768
+
+# -----------------------------
+# POSTGRES
+# -----------------------------
+POSTGRES_USER=admin
+POSTGRES_PASSWORD=admin
+POSTGRES_DB=flowise
+POSTGRES_PORT=5432
+
+# -----------------------------
+# FLOWISE
+# -----------------------------
+FLOWISE_PORT=3000
+DATABASE_SCHEMA=public
+
+OLLAMA_BASE_URL=http://ollama:11434
+
+
+# ========================
+# n8n
+# ========================
+N8N_PORT=5678
+N8N_TIMEZONE=America/Panama
+
+
+
+
+
+##################################  Fleet Compose Configuration  #################
+# -----------------------------
+# MYSQL
+# -----------------------------
+MYSQL_ROOT_PASSWORD=admin123
+MYSQL_DATABASE=fleet
+MYSQL_USER=fleet
+MYSQL_PASSWORD=fleet123
+
+# -----------------------------
+# Fleet Server
+# -----------------------------
+# Generate a random key with: openssl rand -base64 32
+#TODO: CAMBIA ESTA LLAVE EN PRODUCCION... ESTA ESDE PRUEBAS, SOLO PARA DESARROLLO
+FLEET_SERVER_PRIVATE_KEY=5xJNDT0n0w7J3jUuQUdeXyRJ7x3Z/TyVtuL+qlsTM8I=
+
+# Fleet HTTP Listener Configuration
+FLEET_SERVER_ADDRESS=0.0.0.0
+FLEET_SERVER_PORT=1337
+
+# TLS Configuration
+# Set to 'true' if Fleet handles TLS directly (requires certificates in ./certs/)
+# Set to 'false' if using a reverse proxy or load balancer for TLS termination
+FLEET_SERVER_TLS=true
+
+# TLS Certificate paths (only needed if FLEET_SERVER_TLS=true)
+FLEET_SERVER_CERT=/fleet/fleet.crt
+FLEET_SERVER_KEY=/fleet/fleet.key
+
+# Fleet License (optional - leave empty for free tier)
+FLEET_LICENSE_KEY=
+
+# Fleet Session & Logging
+FLEET_SESSION_DURATION=24h
+FLEET_LOGGING_JSON=true
+
+# Fleet Osquery Configuration
+FLEET_OSQUERY_STATUS_LOG_PLUGIN=filesystem
+FLEET_FILESYSTEM_STATUS_LOG_FILE=/logs/osqueryd.status.log
+FLEET_FILESYSTEM_RESULT_LOG_FILE=/logs/osqueryd.results.log
+FLEET_OSQUERY_LABEL_UPDATE_INTERVAL=1h
+
+# Fleet Vulnerabilities
+FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS=yes
+FLEET_VULNERABILITIES_DATABASES_PATH=/vulndb
+FLEET_VULNERABILITIES_PERIODICITY=1h
+
+# S3 Configuration (optional - leave empty if not using S3)
+FLEET_S3_SOFTWARE_INSTALLERS_BUCKET=
+FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID=
+FLEET_S3_SOFTWARE_INSTALLERS_SECRET_ACCESS_KEY=
+FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE=
+FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL=
+FLEET_S3_SOFTWARE_INSTALLERS_REGION=


### PR DESCRIPTION
Introduce un nuevo workspace en src/ai-sentinel para levantar un stack de IA integrado con Fleet.

Incluye:
- docker-compose para dev/prod/test (ollama, postgres pgvector, flowise, n8n y Fleet)
- Dockerfiles y scripts de apoyo (start.sh e init-db.sh)
- Documentación de uso y generación de certificados TLS
- ai_stack.dockerignore para controlar el build context
- .gitignore para ignorar certificados generados (*.crt, *.key)

Nota: reemplazar FLEET_SERVER_PRIVATE_KEY demo antes de usar en producción.

Closes #4 